### PR TITLE
Add Toxiproxy latency experiment

### DIFF
--- a/toxiproxy/introduce_latency/README.md
+++ b/toxiproxy/introduce_latency/README.md
@@ -1,0 +1,102 @@
+# Introduce latency using Toxiproxy
+
+This experiment explores whether my application can robustly respond to an increase in latency, injected
+using the [Toxiproxy][toxiproxy].
+
+[toxiproxy]: http://toxiproxy.io
+
+## Setup for Experiment Execution
+
+### Install the Chaos Toolkit
+
+This experiment uses the [free and open source Chaos Toolkit][chaostoolkit]. The instructions for installing the [Chaos Toolkit][chaostoolkit] are available in the [project's documentation][docs].
+
+[chaostoolkit]: https://chaostoolkit.org/
+[docs]: https://docs.chaostoolkit.org
+
+### Install Any Required Drivers
+
+The [Chaos Toolkit][chaostoolkit] is extended by adding [drivers]. This experiment requires the following drivers:
+
+* Toxiproxy driver [toxiproxy-driver] [toxiproxy-driver-github]
+
+[drivers]: https://docs.chaostoolkit.org/drivers/overview/
+[toxiproxy-driver]: https://docs.chaostoolkit.org/drivers/toxiproxy/
+[toxiproxy-driver-github]: https://github.com/chaostoolkit-incubator/chaostoolkit-toxiproxy
+
+## Running the Experiment
+
+### Required Parameters
+
+This experiment requires the following parameters:
+
+* Environment Variables
+  * `APPLICATION_ENTRYPOINT_URL` - Specifies the application entry point URL where your application can be reached in your environment.
+  * `TOXIPROXY_HOST` - Specifies Toxiproxy URL where the toxiproxy is running.
+  * `TOXIPROXY_PROXY_NAME` - Specifies the toxy name
+
+## Running the Experiment Direct from the Catalog using HTTP
+
+You can run this experiment using the native `chaos` command, or using `docker`.
+
+With the native `chaos` command:
+
+```bash
+(chaostk) $ export APPLICATION_ENTRYPOINT_URL=http://localhost:5000/api/airports; \
+            export TOXIPROXY_HOST=localhost; \
+            export TOXIPROXY_PROXY_NAME=mysql; \
+                   chaos run https://raw.githubusercontent.com/open-chaos/experiment-catalog/master/toxiproxy/introduce_latency/introduce_latency_experiment.json
+```
+
+> ***NOTE:*** The APPLICATION_ENTRYPOINT_URL, TOXIPROXY_HOST & TOXIPROXY_PROXY_NAME should be setup according to your services run time environment. The docker command also uses the .chaostoolkit/settings.yaml from the users home directory.
+
+With `docker`:
+
+```bash
+$ docker run -it \
+           -e APPLICATION_ENTRYPOINT_URL=http://localhost:5000/api/airports; \
+           -e TOXIPROXY_HOST=localhost \
+           -e TOXIPROXY_PROXY_NAME=mysql \
+           -v `pwd`:/tmp/result \
+           -v ~/.chaostoolkit:/tmp/settings \
+           chaostoolkit/chaostoolkit \
+           --settings /tmp/settings/settings.yaml \
+           run https://raw.githubusercontent.com/open-chaos/experiment-catalog/master/toxiproxy/introduce_latency/introduce_latency_experiment.json
+```
+
+
+### Running the Experiment from a Local Copy
+
+You can run this experiment using the native `chaos` command, or using `docker`.
+
+With the native `chaos` command:
+
+```bash
+(chaostk) $ export APPLICATION_ENTRYPOINT_URL=http://localhost:5000/api/airports; \
+            export TOXIPROXY_HOST=localhost; \
+            export TOXIPROXY_PROXY_NAME=mysql; \
+                   chaos run introduce_latency_experiment.json
+```
+
+> ***NOTE:*** The APPLICATION_ENTRYPOINT_URL, TOXIPROXY_HOST & TOXIPROXY_PROXY_NAME should be setup according to your services run time environment. The docker command also uses the .chaostoolkit/settings.yaml from the users home directory.
+
+With `docker`:
+
+```bash
+$ docker run -it \
+           -e APPLICATION_ENTRYPOINT_URL=http://localhost:5000/api/airports; \
+           -e TOXIPROXY_HOST=localhost \
+           -e TOXIPROXY_PROXY_NAME=mysql \
+           -v `pwd`:/tmp/result \
+           -v ~/.chaostoolkit:/tmp/settings \
+           chaostoolkit/chaostoolkit \
+           --settings /tmp/settings/settings.yaml \
+           run introduce_latency_experiment.json
+```
+
+## Note
+
+Due to the [issue #15][issue#15] in the the chaos toolkit toxiproxy driver, based on the chaos toolikit library [issue #137][issue#137], the latency and jitter are hardcoded. Once they are fixed, the experiment will be updated in order to be parametrized.  
+
+[issue#15]: https://github.com/chaostoolkit-incubator/chaostoolkit-toxiproxy/issues/15
+[issue#137]: https://github.com/chaostoolkit/chaostoolkit-lib/issues/137

--- a/toxiproxy/introduce_latency/introduce_latency_experiment.json
+++ b/toxiproxy/introduce_latency/introduce_latency_experiment.json
@@ -1,0 +1,86 @@
+{
+    "version": "1.0.0",
+    "title": "The application should stay within tolerance when dependency responses slow down.",
+    "description": "Uses Toxiproxy to manipulate the connections to a service",
+    "tags": [
+        "platform:toxiproxy",
+        "service:any"
+    ],
+    "configuration": {
+        "service_url": {
+            "type": "env",
+            "key": "APPLICATION_ENTRYPOINT_URL"
+        },
+        "toxiproxy_host": {
+            "type": "env",
+            "key": "TOXIPROXY_HOST"
+        },
+        "toxiproxy_proxy_name": {
+            "type": "env",
+            "key": "TOXIPROXY_PROXY_NAME"
+        }
+    },
+    "contributions": {
+        "availability": "high",
+        "reliability": "high",
+        "performability": "high",
+        "safety": "none",
+        "security": "none"
+    },
+    "steady-state-hypothesis": {
+        "title": "System is healthy",
+        "probes": [
+            {
+                "name": "consumer-service-must-still-respond",
+                "type": "probe",
+                "provider": {
+                    "type": "http",
+                    "url": "${service_url}"
+                },
+                "tolerance": 200,
+                "timeout": 1
+            }
+        ]
+    },
+    "method": [
+        {
+            "name": "create_latency_toxic",
+            "provider": {
+                "arguments": {
+                    "for_proxy": "${toxiproxy_proxy_name}",
+                    "toxic_name": "${toxiproxy_proxy_name}-latency",
+                    "latency": 1200,
+                    "jitter": 100
+                },
+                "func": "create_latency_toxic",
+                "module": "chaostoxi.toxic.actions",
+                "type": "python"
+            },
+            "type": "action",
+            "pauses": {
+                "after": 1
+            }
+        },
+        {
+            "name": "delete_toxic",
+            "provider": {
+                "arguments": {
+                    "for_proxy": "${toxiproxy_proxy_name}",
+                    "toxic_name": "${toxiproxy_proxy_name}_latency"
+                },
+                "func": "delete_toxic",
+                "module": "chaostoxi.toxic.actions",
+                "type": "python"
+            },
+            "type": "action",
+            "pauses": {
+                "after": 1
+            }
+        }
+    ],
+    "rollbacks": [
+        {
+            "ref": "delete_toxic"
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds a latency experiment using Toxiproxy. The setup creates and deletes the toxy.
Base on issue #15, the `latency` and `jitter` are hardcoded. Once it is fixed, the experiment will be updated.