### PR TITLE
Fix support for POD_NAMESPACE in kill_pod_by_label_experiment for k8s

### DIFF
--- a/kubernetes/kill_pod_by_label/kill_pod_by_label_experiment.json
+++ b/kubernetes/kill_pod_by_label/kill_pod_by_label_experiment.json
@@ -14,6 +14,10 @@
         "pod_label_selector": {
             "type": "env",
             "key": "POD_LABEL"
+        },
+        "namespace": {
+            "type": "env",
+            "key": "POD_NAMESPACE"
         }
     },
     "contributions": {
@@ -47,7 +51,8 @@
                 "type": "python",
                 "func": "terminate_pods",
                 "arguments": {
-                    "label_selector": "${pod_label_selector}"
+                    "label_selector": "${pod_label_selector}",
+                    "ns": "${namespace}"
                 }
             },
             "pauses": {


### PR DESCRIPTION
This PR adds support for `POD_NAMESPACE` as is described in the [documentation](https://github.com/open-chaos/experiment-catalog/tree/master/kubernetes/kill_pod_by_label) and was missing. 